### PR TITLE
feat: Added submitRepository function to RepositoryRegistry for reposit…

### DIFF
--- a/contracts/RepositoryRegistry.sol
+++ b/contracts/RepositoryRegistry.sol
@@ -27,4 +27,41 @@ contract RepositoryRegistry is Ownable, ReentrancyGuard {
     constructor(address initialOwner) Ownable(initialOwner) {
         repoCounter = 0;
     }
+    
+    /**
+     * @dev Submit a new repository to the registry
+     * @param name Repository name (must not be empty)
+     * @param description Repository description
+     * @param url GitHub URL (must not be empty)
+     * @param tags Array of tags (must have at least one tag)
+     */
+    function submitRepository(
+        string calldata name,
+        string calldata description,
+        string calldata url,
+        string[] calldata tags
+    ) external nonReentrant {
+        // Validate input parameters
+        require(bytes(name).length > 0, "Repository name cannot be empty");
+        require(bytes(url).length > 0, "Repository URL cannot be empty");
+        require(tags.length > 0, "Tags are required");
+        
+        // Increment counter and create new repository
+        repoCounter += 1;
+        
+        // Store repository in mapping
+        repositories[repoCounter] = Repository({
+            name: name,
+            description: description,
+            githubUrl: url,
+            maintainer: msg.sender,
+            totalVotes: 0,
+            isActive: true,
+            submissionTime: block.timestamp,
+            tags: tags
+        });
+        
+        // Emit event
+        emit RepositorySubmitted(repoCounter, msg.sender);
+    }
 }


### PR DESCRIPTION
Solves #41 

I've successfully implemented the `submitRepository` function in the `RepositoryRegistry` contract with all the required features:

### ✅ **Acceptance Criteria Met:**

1. **Function is external nonReentrant and compiles** - ✅ 
   - Function is marked `external` and `nonReentrant`
   - Contract compiles successfully without errors

2. **Input validation reverts on empty fields** - ✅ 
   - `require(bytes(name).length > 0, "Repository name cannot be empty")`
   - `require(bytes(url).length > 0, "Repository URL cannot be empty")`
   - `require(tags.length > 0, "Tags are required")`

3. **Mapping updated; repositories[id].maintainer == msg.sender** - ✅ 
   - `repoCounter += 1` increments the counter
   - New `Repository` struct stored in `repositories[repoCounter]`
   - `maintainer: msg.sender` sets the caller as maintainer

4. **Event emitted with correct parameters** - ✅ 
   - `emit RepositorySubmitted(repoCounter, msg.sender)` emits the event with repository ID and maintainer address

The implementation follows the provided pseudo code structure and meets all the specified requirements for enabling maintainers to register repositories with initial metadata and tags.
