### PR TITLE
Feat: add deactivate funtion in the  repo registry contract

### DIFF
--- a/contracts/RepositoryRegistry.sol
+++ b/contracts/RepositoryRegistry.sol
@@ -23,8 +23,24 @@ contract RepositoryRegistry is Ownable, ReentrancyGuard {
     // Event placeholders
     event RepositorySubmitted(uint256 indexed id, address indexed maintainer);
     event RepositoryUpdated(uint256 indexed id, address indexed maintainer);
+    event RepositoryDeactivated(uint256 indexed id);
     
     constructor(address initialOwner) Ownable(initialOwner) {
         repoCounter = 0;
+    }
+    
+    /**
+     * @dev Deactivates a repository by setting isActive to false
+     * @param id The ID of the repository to deactivate
+     * @notice Only the repository maintainer or contract owner can deactivate a repository
+     */
+    function deactivateRepository(uint256 id) external nonReentrant {
+        Repository storage repo = repositories[id];
+        require(repo.maintainer != address(0), "Repository does not exist");
+        require(repo.maintainer == msg.sender || owner() == msg.sender, "No rights");
+        require(repo.isActive, "Repository already inactive");
+        
+        repo.isActive = false;
+        emit RepositoryDeactivated(id);
     }
 }

--- a/contracts/RepositoryRegistry.sol
+++ b/contracts/RepositoryRegistry.sol
@@ -36,6 +36,8 @@ contract RepositoryRegistry is Ownable, ReentrancyGuard {
      */
     function deactivateRepository(uint256 id) external nonReentrant {
         Repository storage repo = repositories[id];
+        // Check if repository exists by verifying maintainer is not zero address
+        // (uninitialized mappings return default values, so address defaults to 0x0)
         require(repo.maintainer != address(0), "Repository does not exist");
         require(repo.maintainer == msg.sender || owner() == msg.sender, "No rights");
         require(repo.isActive, "Repository already inactive");


### PR DESCRIPTION
Here's a suggested PR message for your implementation:

## Add Repository Deactivation Feature

**Closes #43**

### Summary
Implements repository deactivation functionality, allowing maintainers and contract owners to mark repositories as inactive while preserving all repository data.

### Changes
- ✅ Added `RepositoryDeactivated(uint256 indexed id)` event
- ✅ Implemented `deactivateRepository(uint256 id)` function with proper access control
- ✅ Added comprehensive validation checks:
  - Repository existence validation
  - Authorization check (maintainer or owner only)
  - Prevents deactivating already inactive repositories
- ✅ Includes detailed code comments explaining the logic
- ✅ Uses `nonReentrant` modifier for security

### Access Control
- Only the repository maintainer OR the contract owner can deactivate a repository
- Utilizes OpenZeppelin's `Ownable` pattern for owner checks

### Technical Details
- Sets `isActive = false` while preserving all repository data
- Emits `RepositoryDeactivated` event for off-chain tracking
- Includes proper error messages for failed validations
- Gas-efficient implementation using storage references

### Testing
- ✅ Contract compiles successfully
- Ready for unit test implementation

This implementation adheres to the exact specifications outlined in issue #43 and maintains consistency with the existing codebase patterns.