### PR TITLE
feat: Add DEVoterVoting contract and interfaces for voting and repository management

### DIFF
--- a/contracts/DEVoterVoting.sol
+++ b/contracts/DEVoterVoting.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+/**
+ * @title IDEVoterEscrow
+ * @dev Interface for the DEVoterEscrow contract
+ */
+interface IDEVoterEscrow {
+    function hasActiveEscrow(address user) external view returns (bool);
+    function getUserEscrowAmount(address user) external view returns (uint256);
+    function castVote(uint256 repositoryId, uint256 amount) external;
+}
+
+/**
+ * @title IRepositoryRegistry
+ * @dev Interface for the RepositoryRegistry contract
+ */
+interface IRepositoryRegistry {
+    struct Repository {
+        string name;
+        string description;
+        string githubUrl;
+        address maintainer;
+        uint256 totalVotes;
+        bool isActive;
+        uint256 submissionTime;
+        string[] tags;
+    }
+    
+    function getRepositoryDetails(uint256 id) external view returns (Repository memory);
+    function isRepositoryActive(uint256 id) external view returns (bool);
+}
+
+/**
+ * @title DEVoterVoting
+ * @dev Main voting contract that interfaces with DEVoterEscrow and RepositoryRegistry
+ */
+contract DEVoterVoting is Ownable, ReentrancyGuard {
+    IDEVoterEscrow public escrowContract;
+    IRepositoryRegistry public registryContract;
+    
+    /**
+     * @dev Constructor to initialize the voting contract
+     * @param _escrow Address of the DEVoterEscrow contract
+     * @param _registry Address of the RepositoryRegistry contract
+     * @param initialOwner Address of the initial owner
+     */
+    constructor(
+        address _escrow, 
+        address _registry,
+        address initialOwner
+    ) Ownable(initialOwner) {
+        require(_escrow != address(0), "Invalid escrow address");
+        require(_registry != address(0), "Invalid registry address");
+        
+        escrowContract = IDEVoterEscrow(_escrow);
+        registryContract = IRepositoryRegistry(_registry);
+    }
+}

--- a/contracts/RepositoryRegistry.sol
+++ b/contracts/RepositoryRegistry.sol
@@ -44,6 +44,7 @@ contract RepositoryRegistry is Ownable, ReentrancyGuard {
         emit RepositoryUpdated(id, msg.sender);
     }
 
+    /**
      * @dev Submit a new repository to the registry
      * @param name Repository name (must not be empty)
      * @param description Repository description
@@ -80,6 +81,7 @@ contract RepositoryRegistry is Ownable, ReentrancyGuard {
         emit RepositorySubmitted(repoCounter, msg.sender);
     }
 
+    /**
      * @dev Deactivates a repository by setting isActive to false
      * @param id The ID of the repository to deactivate
      * @notice Only the repository maintainer or contract owner can deactivate a repository


### PR DESCRIPTION
Closes #53 

Implemented the following:

- Created DEVoterVoting.sol file in contracts directory
- Imported OpenZeppelin contracts (Ownable, ReentrancyGuard)
- Defined IDEVoterEscrow and IRepositoryRegistry interfaces
- Declared contract inheritance and basic state variables