### PR TITLE
Refactor: remove unused event, legacy getter, optimize vote query

### DIFF
--- a/contracts/DEVoterEscrow.sol
+++ b/contracts/DEVoterEscrow.sol
@@ -73,12 +73,8 @@ contract DEVoterEscrow is ReentrancyGuard, Ownable, Pausable, AccessControl {
         uint256 releaseTime,
         bool wasForced
     );
-    event VoteCast(
-        address indexed user, 
-        uint256 indexed repositoryId, 
-        uint256 amount,
-        uint256 timestamp
-    );
+    // Removed unused VoteCast event. Only VoteCasted is used for voting actions.
+    // Rationale: Only one event is needed for vote actions to avoid confusion and redundancy.
     event FeeParametersUpdated(
         uint256 newFeePercentage, 
         address indexed newFeeCollector,
@@ -379,7 +375,7 @@ contract DEVoterEscrow is ReentrancyGuard, Ownable, Pausable, AccessControl {
         
         emit FeeBasisPointsUpdated(oldFeeBasisPoints, newFeeBasisPoints);
         emit FeeParametersUpdated(
-            (newFeeBasisPoints * 100) / BASIS_POINTS_DENOMINATOR, 
+            newFeeBasisPoints, // Now emits raw basis points for clarity instead of percentage
             feeWallet, 
             msg.sender
         );
@@ -397,7 +393,7 @@ contract DEVoterEscrow is ReentrancyGuard, Ownable, Pausable, AccessControl {
         
         emit FeeWalletUpdated(oldFeeWallet, newFeeWallet);
         emit FeeParametersUpdated(
-            (feeBasisPoints * 100) / BASIS_POINTS_DENOMINATOR, 
+            feeBasisPoints, // Now emits raw basis points for clarity instead of percentage
             newFeeWallet, 
             msg.sender
         );
@@ -691,10 +687,8 @@ contract DEVoterEscrow is ReentrancyGuard, Ownable, Pausable, AccessControl {
         return feeWallet;
     }
 
-    function getFeePercentage() external view returns (uint256) {
-        // Convert basis points to percentage for backward compatibility
-        return (feeBasisPoints * 100) / BASIS_POINTS_DENOMINATOR;
-    }
+    // Removed legacy getFeePercentage getter for clarity. Use getFeeInfo for raw basis points.
+    // Rationale: getFeeInfo provides all fee details in basis points, which is the standard for smart contracts.
 
     function getTokenAddress() external view returns (address) {
         return address(token);


### PR DESCRIPTION
Here’s a summary of the tasks completed

1. **DEVoterEscrow.sol**
   - Removed the unused `VoteCast` event, clarifying that only `VoteCasted` is used for voting actions.
   - Updated the `FeeParametersUpdated` event to emit raw basis points instead of percentage for clarity.
   - Removed the legacy `getFeePercentage` getter, with comments explaining that `getFeeInfo` should be used for fee details.

2. **DEVoterVoting.sol**
   - Fixed the logic for updating `voterCount` in `castVote` to accurately track unique voters.
   - Optimized the `getUserVoteForRepository` function to return early when a match is found and avoid unnecessary looping if the user hasn’t voted, with comments explaining the rationale.

All changes were documented with comments for clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Breaking Changes
  * Removed legacy VoteCast event; existing VoteCasted event is used for voting actions.
  * Removed getFeePercentage; use getFeeInfo for fee details in basis points.
* Improvements
  * Fee update events now emit raw basis points for consistent reporting.
  * Faster queries when retrieving a user’s vote for a repository.
* Changes
  * Updated logic for tracking voter counts when casting votes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->