### PR TITLE
Allow zero submission fee submissions

### DIFF
--- a/contracts/RepositoryRegistry.sol
+++ b/contracts/RepositoryRegistry.sol
@@ -95,9 +95,10 @@ contract RepositoryRegistry is Ownable, ReentrancyGuard {
             }
         }
 
-        // Require fee payment
-        require(submissionFee > 0, "Submission fee not set");
-        token.safeTransferFrom(msg.sender, feeWallet, submissionFee);
+        // Transfer submission fee only when configured
+        if (submissionFee > 0) {
+            token.safeTransferFrom(msg.sender, feeWallet, submissionFee);
+        }
 
         // Increment counter and create new repository
         repoCounter += 1;

--- a/test/RepositoryRegistry.ts
+++ b/test/RepositoryRegistry.ts
@@ -378,6 +378,44 @@ describe("RepositoryRegistry", function () {
       expect(repo.isActive).to.be.true;
     });
 
+    it("Should allow submissions when the fee is set to zero", async function () {
+      const {
+        repositoryRegistry,
+        maintainer1,
+        owner,
+        mockDEVToken,
+        feeWallet,
+      } = await loadFixture(deployRepositoryRegistryFixture);
+
+      await repositoryRegistry.write.setSubmissionFee([0n], {
+        account: owner.account,
+      });
+
+      const name = "Zero Fee Repo";
+      const description = "Repository created without a submission fee";
+      const url = "https://github.com/test/zerofee";
+      const tags = ["zero-fee"];
+
+      const feeWalletBefore = await mockDEVToken.read.balanceOf([
+        feeWallet.account.address,
+      ]);
+
+      await repositoryRegistry.write.submitRepository(
+        [name, description, url, tags],
+        { account: maintainer1.account }
+      );
+
+      const repo = await repositoryRegistry.read.getRepositoryDetails([1n]);
+      const feeWalletAfter = await mockDEVToken.read.balanceOf([
+        feeWallet.account.address,
+      ]);
+
+      expect(repo.name).to.equal(name);
+      expect(repo.description).to.equal(description);
+      expect(repo.isActive).to.be.true;
+      expect(feeWalletAfter).to.equal(feeWalletBefore);
+    });
+
     it("Should handle single character inputs correctly", async function () {
       const { repositoryRegistry, maintainer1 } = await loadFixture(
         deployRepositoryRegistryFixture


### PR DESCRIPTION
**Summary**
- Prevent `submitRepository` from reverting when the submission fee is zero by skipping the token transfer in that case.
- Add a regression test confirming zero-fee submissions succeed and no tokens leave the maintainer.

**Testing**
- `npx hardhat test --grep RepositoryRegistry`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Repository submissions now proceed without charging a fee when the configured fee is zero. Fee transfers occur only when a positive fee is set. Existing submission flow remains unchanged.
- Tests
  - Added test coverage to validate zero-fee submissions, ensuring no tokens are transferred and submissions complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->