### PR TITLE
feat: Add Fee Calculation Constants and Docs Reference to DEVoterTreasury

### DIFF
--- a/contracts/DEVoterTreasury.sol
+++ b/contracts/DEVoterTreasury.sol
@@ -10,7 +10,7 @@ pragma solidity ^0.8.0;
  * Key constants for fee calculation:
  * - BASIS_POINTS_DENOMINATOR = 10000 (for 0.01% precision)
  * - MAX_FEE_BASIS_POINTS = 500 (representing 5%)
- * - MIN_FEE_BASIS_POINTS = 0 (representing 0%)
+ * - MIN_FEE_BASIS_POINTS = 0 (representing 0%, defined in DEVoterEscrow.sol)
  *
  * Integer division truncates (rounds down). Small amounts may yield a zero fee.
  * The computed fee is typically capped so it never exceeds the `amount`.

--- a/contracts/DEVoterTreasury.sol
+++ b/contracts/DEVoterTreasury.sol
@@ -2,8 +2,23 @@
 pragma solidity ^0.8.0;
 
 /**
+ * @notice Protocol Fee Calculation System Overview
+ * @dev This contract is part of a system that may involve fee calculations.
+ * The canonical formula for fee calculation across the protocol is:
+ * `fee = (amount * feeBasisPoints) / BASIS_POINTS_DENOMINATOR`
+ *
+ * Key constants for fee calculation:
+ * - BASIS_POINTS_DENOMINATOR = 10000 (for 0.01% precision)
+ * - MAX_FEE_BASIS_POINTS = 500 (representing 5%)
+ * - MIN_FEE_BASIS_POINTS = 0 (representing 0%)
+ *
+ * Integer division truncates (rounds down). Small amounts may yield a zero fee.
+ * The computed fee is typically capped so it never exceeds the `amount`.
+ * For a comprehensive explanation, refer to `docs/FeeCalculationSystem.md`.
+ */
+/**
  * @title DEVoterTreasury
- * @dev A treasury contract to securely hold and manage protocol funds, with controlled withdrawal mechanisms.
+ * @dev A treasury contract to securely hold and manage protocol funds, with controlled withdrawal mechanisms. For details on fee calculation, refer to docs/FeeCalculationSystem.md.
  */
 contract DEVoterTreasury {
     address public owner; /**
@@ -15,6 +30,9 @@ contract DEVoterTreasury {
     mapping(address => bool) public authorized; /**
      * @dev Mapping to track which addresses are authorized to perform withdrawals.
      */
+
+    uint256 public constant BASIS_POINTS_DENOMINATOR = 10000;
+    uint256 public constant MAX_FEE_BASIS_POINTS = 500; // Represents 5%
 
     event Deposit(address indexed from, uint256 amount);
     event Withdrawal(address indexed to, uint256 amount);

--- a/docs/FeeCalculationSystem.md
+++ b/docs/FeeCalculationSystem.md
@@ -9,6 +9,8 @@ This document explains the fee system implemented in `DEVoterEscrow`. It describ
 - exemption and administrative controls
 - rounding behaviour and common edge cases
 
+Note: A summary of the fee calculation logic and key constants are also captured in the contract comments of `DEVoterTreasury.sol`.
+
 ## Basis points (bps) refresher
 
 - 1 basis point (1 bps) = 0.01%


### PR DESCRIPTION
Overview: Added fee calculation constants and a documentation reference to `DEVoterTreasury.sol`.

## Changes

- Introduced `BASIS_POINTS_DENOMINATOR` and `MAX_FEE_BASIS_POINTS` constants to `DEVoterTreasury.sol`.
- Added a contract-level comment block summarizing the fee calculation logic.
- Updated contract comments to reference the detailed `docs/FeeCalculationSystem.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fee calculation parameters are now publicly defined as standardized contract constants (denominator and maximum fee in basis points), improving on-chain transparency.

* **Documentation**
  * Fee calculation docs updated to reference the contract's standardized fee constants and clarify coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->